### PR TITLE
Use relative path in filepath matching

### DIFF
--- a/editorconfig/get-config.js
+++ b/editorconfig/get-config.js
@@ -3,11 +3,12 @@ const loopRoot = require('./loop-root');
 const sortBy = (array, prop) => array.sort((a, b) => a[prop] - b[prop]);
 const clone = require('clone');
 const extend = require('extend');
+const path = require('path');
 
 module.exports = (file) => getRoot(file).then((root) => {
   const options = [];
   loopRoot(root, (option) => {
-    if (option._pattern(file)) {
+    if (option._pattern(path.relative(option._dir, file))) {
       options.push(option);
     }
   });
@@ -20,5 +21,6 @@ module.exports = (file) => getRoot(file).then((root) => {
   const ret = options[0];
   delete ret._priority;
   delete ret._pattern;
+  delete ret._dir;
   return ret;
 });

--- a/editorconfig/get-root.js
+++ b/editorconfig/get-root.js
@@ -38,6 +38,14 @@ const _getRootByDir = getRoot._getRootByDir = function (dir) {
     .catch(() =>
       dir === '/' ? defaults : this.getRootByDir(parentDir(dir))
     )
+    .then((options) => {
+      for (const k in options) {
+        if (typeof options[k] === 'object') {
+          options[k]._dir = dir;
+        }
+      }
+      return options;
+    })
     .then((options) =>
       (options.root || (dir === '/')) ?
         options :

--- a/test/get-root-and-config.spec.js
+++ b/test/get-root-and-config.spec.js
@@ -34,6 +34,7 @@ test.after('Restore `fs.readFile`', () => {
 const cleanClone = (root) => loopRoot(clone(root), (option, pattern, rootCloned) => {
   delete rootCloned[pattern]._priority;
   delete rootCloned[pattern]._pattern;
+  delete rootCloned[pattern]._dir;
 });
 
 const zRoot = (t, file, expected) => getRoot(file).tap(


### PR DESCRIPTION
EditorConfig permits relative path in section names:

```
# Indentation override for all JS under lib directory
[lib/**.js]
indent_style = space
indent_size = 2
```
(from: http://editorconfig.org/)

But above config fails because `textlint-rule-editorconfig` compares *absolute* path of the target file with patterns written in `.editorconfig`.

```js
new Minimatch('lib/**.js').match('/full/path/to/lib/some.js') // => false
```

This PR fixes it.